### PR TITLE
do not define virtualenv interpreter per default

### DIFF
--- a/vex/options.py
+++ b/vex/options.py
@@ -20,7 +20,7 @@ def make_arg_parser():
         '--python',
         help="specify which python for virtualenv to be made",
         action="store",
-        default="python",
+        default=None,
     )
     make.add_argument(
         '--site-packages',


### PR DESCRIPTION
This is a saner default than the current behavior IMO and solves #11 for me.
