### PR TITLE
Expose virtualenv option to not install wheel

### DIFF
--- a/vex/make.py
+++ b/vex/make.py
@@ -55,6 +55,8 @@ def handle_make(environ, options, make_path):
         args += ['--system-site-packages']
     if options.always_copy:
         args+= ['--always-copy']
+    if options.no_wheel:
+        args+= ['--no-wheel']
     returncode = run(args, env=environ, cwd=ve_base)
     if returncode != 0:
         raise exceptions.VirtualenvNotMade("error creating virtualenv")

--- a/vex/options.py
+++ b/vex/options.py
@@ -32,6 +32,11 @@ def make_arg_parser():
         help="use copies instead of symlinks in new virtualenv",
         action="store_true",
     )
+    make.add_argument(
+        '--no-wheel',
+        help="do not install wheel in the new virtualenv",
+        action="store_true",
+    )
 
     remove = parser.add_argument_group(title='To remove a virtualenv')
     remove.add_argument(

--- a/vex/shell_configs/fish
+++ b/vex/shell_configs/fish
@@ -75,6 +75,7 @@ complete -c vex -l make -n "__fish_no_arguments" -d "create named virtualenv bef
 complete -c vex -l python -n "__fish_contains_opt make" -a PYTHON -d "specify python to use with --make"
 complete -c vex -l site-packages -n "__fish_contains_opt make" -d "allow import of site packages from new virtualenv"
 complete -c vex -l always-copy -n "__fish_contains_opt make" -d "copy files instead of creating symlinks when making virtualenv"
+complete -c vex -l no-wheel -n "__fish_contains_opt make" -d "do not install wheel in the new virtualenv"
 complete -c vex -l remove -s r -n "__fish_no_arguments" -d "remove named virtualenv after running"
 
 # any switches on the end - no clear way to stop the processing!

--- a/vex/shell_configs/zsh
+++ b/vex/shell_configs/zsh
@@ -14,6 +14,7 @@ _vex() {
             '--python[use the named python when making virtualenv]:python:(${pythons})' \
             '--site-packages[made virtualenv allows access to site packages]' \
             '--always-copy[copy files instead of making symlinks]' \
+            '--no-wheel[do not install wheel in the new virtualenv]' \
         '(-r --remove)'{-r,--remove}'[remove the named virtualenv after running command]' \
         '(1)--path[set path to virtualenv]:virtualenv directory:_path_files -/' \
         '(--path)1:virtualenv:_path_files -/ -W "$WORKON_HOME"' \


### PR DESCRIPTION
In some cases we want a virtaulenv without wheel support, so this commit
exposes the virtualenv option (added in 13.0.0) to vex as a make option.