### PR TITLE
Vex can now be called as a module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     packages=['vex'],
     package_data={'vex': ['shell_configs/*']},
     scripts=['scripts/vex'],
-    entry_points = {
-        'console_scripts': ['vex = vex.main:main'],
+    entry_points={
+        'console_scripts': ['vex = vex.__main__:main'],
     },
     classifiers=[
         "Topic :: Utilities",

--- a/vex/__main__.py
+++ b/vex/__main__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# flake8: noqa
+from .main import main
+
+
+main()


### PR DESCRIPTION
I found this to be really valuable when testing.

```
$ python -m vex ....
```