### PR TITLE
functional_tests: Inject PYTHONPATH

### DIFF
--- a/vex/functional_tests/test_basic.py
+++ b/vex/functional_tests/test_basic.py
@@ -32,6 +32,7 @@ class Run(object):
     def __init__(self, args=None, env=None, timeout=None):
         self.args = args or []
         self.env = env.copy() if env else {}
+        self.env['PYTHONPATH'] = os.environ['PYTHONPATH']
         self.timeout = timeout
         #
         self.timer = None


### PR DESCRIPTION
The tests fail when the installation prefix is different
from the Python prefix, and PYTHONPATH is used to map the
installation prefix into the current Python namespace.