### PR TITLE
Remove __PYVENV_LAUNCHER__ from the environment for child processes.

### DIFF
--- a/vex/run.py
+++ b/vex/run.py
@@ -18,6 +18,9 @@ def get_environ(environ, defaults, ve_path):
     if "PYTHONHOME" in env:
         del env["PYTHONHOME"]
 
+    if "__PYVENV_LAUNCHER__" in env:
+        del env["__PYVENV_LAUNCHER__"]
+
     # Now we have to adjust PATH to find scripts for the virtualenv...
     # PATH being unset/empty is OK, but ve_path must be set
     # or there is nothing for us to do here and it's bad.


### PR DESCRIPTION
For framework builds of Python on macOS, if __PYVENV_LAUNCHER__ exists,
it's used as the value of sys.executable, and thus is used as the base
for a raft of values, including the system directories in sys.path.
(See: site.py in Python source)

Additionally, python sets this in the environment for subprocesses,
as a way to get around some technical issues with launching scripts
that use the GUI. (See: Mac/Tools/pythonw.c in Python source)

Thus, when vex exec's <virtualenv>/bin/python, the python launched
thinks it's actually vex's python, at /opt/local/bin/python
(or whatever), and so adds the non-virtualenv paths to sys.path.