### PR TITLE
Fix fish shell completion to be compatible with macOS/BSD

### DIFF
--- a/vex/shell_configs/fish
+++ b/vex/shell_configs/fish
@@ -65,6 +65,7 @@ end
 
 # If we source this, we want to wipe out previously defined vex completions
 complete -e -c vex
+complete --no-files -c vex
 # Two positional arguments, a virtualenv and a command.
 complete -c vex -n "__vex_needs_virtualenv" -d "Virtualenv" -f -a "(__vex_list_virtualenvs)"
 complete -c vex -n "__vex_needs_command" -d "Command from Virtualenv" -x -a "(__vex_list_commands)"
@@ -72,8 +73,8 @@ complete -c vex -n "__vex_needs_command" -d "Command from Virtualenv" -x -a "(__
 complete -c vex -l help -s h -n "__fish_no_arguments" -d "print help information"
 complete -c vex -l path -x -a "(__fish_complete_directories)" -d "Give absolute path to virtualenv"
 complete -c vex -l cwd -x -a "(__fish_complete_directories)" -d "Give directory to run in"
-complete -c vex -l config -r -a "" -d "Give path to vexrc file"
-complete -c vex -l shell-config -r -a "fish zsh bash" -d "print evaluable shell config"
+complete -c vex -l config -r -a "(__fish_complete_path)" -d "Give path to vexrc file"
+complete --no-files -c vex -l shell-config -r -a "fish zsh bash" -d "print evaluable shell config"
 complete -c vex -l make -s m -n "__fish_no_arguments" -d "create named virtualenv before running"
 # Options which should only be offered if user gave --make.
 complete -c vex -l python -n "__fish_contains_opt -s m make" -a PYTHON -d "specify python to use with --make"

--- a/vex/shell_configs/fish
+++ b/vex/shell_configs/fish
@@ -39,7 +39,7 @@ end
 
 function __vex_list_virtualenvs
     # echo the names of virtualenvs available as 'vex VENVNAME'.
-	set dirs (find "$WORKON_HOME" -maxdepth 2 -name "bin" -type d -not -empty | xargs dirname)
+	set dirs (find "$WORKON_HOME" -maxdepth 2 -name "bin" -type d -not -empty | xargs -n 1 dirname)
 	for NAME in $dirs
 		basename $NAME
 	end

--- a/vex/shell_configs/fish
+++ b/vex/shell_configs/fish
@@ -16,7 +16,9 @@ function __vex_needs_virtualenv
   set args (__vex_positional_args)
   set opts (__vex_optional_args)
   for opt in $opts
-	if [ $opt = '--path' -o $opt = '--make' -o $opt = '-m' ]
+    # Add 'x' as a prefix to workaround
+    # https://github.com/fish-shell/fish-shell/issues/5186#issuecomment-421244106
+	if [ x$opt = 'x--path' -o x$opt = 'x--make' -o x$opt = 'x-m' ]
 		return 1
 	end
   end
@@ -75,7 +77,7 @@ complete -c vex -l make -s m -n "__fish_no_arguments" -d "create named virtualen
 complete -c vex -l python -n "__fish_contains_opt -s m make" -a PYTHON -d "specify python to use with --make"
 complete -c vex -l site-packages -n "__fish_contains_opt -s m make" -d "allow import of site packages from new virtualenv"
 complete -c vex -l always-copy -n "__fish_contains_opt -s m make" -d "copy files instead of creating symlinks when making virtualenv"
-complete -c vex -l remove -s r -n "__fish_no_arguments" -d "remove named virtualenv after running"
+complete -c vex -l remove -s r -n "__vex_needs_virtualenv" -d "remove named virtualenv after running"
 
 # any switches on the end - no clear way to stop the processing!
 #complete -c vex -u

--- a/vex/shell_configs/fish
+++ b/vex/shell_configs/fish
@@ -70,11 +70,11 @@ complete -c vex -l path -x -a "(__fish_complete_directories)" -d "Give absolute 
 complete -c vex -l cwd -x -a "(__fish_complete_directories)" -d "Give directory to run in"
 complete -c vex -l config -r -a "" -d "Give path to vexrc file"
 complete -c vex -l shell-config -r -a "fish zsh bash" -d "print evaluable shell config"
-complete -c vex -l make -n "__fish_no_arguments" -d "create named virtualenv before running"
+complete -c vex -l make -s m -n "__fish_no_arguments" -d "create named virtualenv before running"
 # Options which should only be offered if user gave --make.
-complete -c vex -l python -n "__fish_contains_opt make" -a PYTHON -d "specify python to use with --make"
-complete -c vex -l site-packages -n "__fish_contains_opt make" -d "allow import of site packages from new virtualenv"
-complete -c vex -l always-copy -n "__fish_contains_opt make" -d "copy files instead of creating symlinks when making virtualenv"
+complete -c vex -l python -n "__fish_contains_opt -s m make" -a PYTHON -d "specify python to use with --make"
+complete -c vex -l site-packages -n "__fish_contains_opt -s m make" -d "allow import of site packages from new virtualenv"
+complete -c vex -l always-copy -n "__fish_contains_opt -s m make" -d "copy files instead of creating symlinks when making virtualenv"
 complete -c vex -l remove -s r -n "__fish_no_arguments" -d "remove named virtualenv after running"
 
 # any switches on the end - no clear way to stop the processing!

--- a/vex/shell_configs/fish
+++ b/vex/shell_configs/fish
@@ -39,7 +39,7 @@ end
 
 function __vex_list_virtualenvs
     # echo the names of virtualenvs available as 'vex VENVNAME'.
-	set dirs (find "$WORKON_HOME" -maxdepth 2 -name "bin" -type d -not -empty -printf '%h\n')
+	set dirs (find "$WORKON_HOME" -maxdepth 2 -name "bin" -type d -not -empty | xargs dirname)
 	for NAME in $dirs
 		basename $NAME
 	end
@@ -52,7 +52,7 @@ function __vex_list_commands
 	if [ (count $cmd) -eq 2 -a $cmd[1] = 'vex' ]
 	    set ve "$WORKON_HOME/$cmd[2]"
 	    if test -f "$ve/bin"
-			find "$ve/bin" -maxdepth 1 -executable -printf '%f\n'
+			find "$ve/bin" -maxdepth 1 -executable | xargs basename
 		end
 	end
 	set -l ctoken (commandline -ct)
@@ -62,7 +62,7 @@ end
 # If we source this, we want to wipe out previously defined vex completions
 complete -e -c vex
 # Two positional arguments, a virtualenv and a command.
-complete -c vex -n "__vex_needs_virtualenv" -d "Virtualenv" -f -a "(__vex_list_virtualenvs)" 
+complete -c vex -n "__vex_needs_virtualenv" -d "Virtualenv" -f -a "(__vex_list_virtualenvs)"
 complete -c vex -n "__vex_needs_command" -d "Command from Virtualenv" -x -a "(__vex_list_commands)"
 # Other options.
 complete -c vex -l help -s h -n "__fish_no_arguments" -d "print help information"

--- a/vex/shell_configs/fish
+++ b/vex/shell_configs/fish
@@ -58,7 +58,9 @@ function __vex_list_commands
 		end
 	end
 	set -l ctoken (commandline -ct)
-	complete -C$ctoken
+  if not string match -- '-*' $ctoken
+    complete -C$ctoken
+  end
 end
 
 # If we source this, we want to wipe out previously defined vex completions

--- a/vex/shell_configs/fish
+++ b/vex/shell_configs/fish
@@ -12,11 +12,11 @@ end
 function __vex_needs_virtualenv
   # Return 0 if we should expect a virtualenv arg.
   # This is normally if there were no positional args after 'vex'.
-  # But we also don't need it if we already saw --path.
+  # But we also don't need it if we already saw --path or --make.
   set args (__vex_positional_args)
   set opts (__vex_optional_args)
   for opt in $opts
-	if [ $opt = '--path' ]
+	if [ $opt = '--path' -o $opt = '--make' -o $opt = '-m' ]
 		return 1
 	end
   end

--- a/vex/shell_configs/fish
+++ b/vex/shell_configs/fish
@@ -77,7 +77,7 @@ complete -c vex -l config -r -a "(__fish_complete_path)" -d "Give path to vexrc 
 complete --no-files -c vex -l shell-config -r -a "fish zsh bash" -d "print evaluable shell config"
 complete -c vex -l make -s m -n "__fish_no_arguments" -d "create named virtualenv before running"
 # Options which should only be offered if user gave --make.
-complete -c vex -l python -n "__fish_contains_opt -s m make" -a PYTHON -d "specify python to use with --make"
+complete -c vex -l python -n "__fish_contains_opt -s m make" -x -a "(__vex_list_commands)" -d "specify python to use with --make"
 complete -c vex -l site-packages -n "__fish_contains_opt -s m make" -d "allow import of site packages from new virtualenv"
 complete -c vex -l always-copy -n "__fish_contains_opt -s m make" -d "copy files instead of creating symlinks when making virtualenv"
 complete -c vex -l remove -s r -n "__vex_needs_virtualenv" -d "remove named virtualenv after running"


### PR DESCRIPTION
`find` on macOS/BSD doesn't support `-printf`. See also conda/conda#7575.

I also added some other fixes and enhancements to the fish shell completions, commit by commit.