### PR TITLE
Fix fish shell completion to be compatible with macOS

### DIFF
--- a/vex/shell_configs/fish
+++ b/vex/shell_configs/fish
@@ -39,7 +39,7 @@ end
 
 function __vex_list_virtualenvs
     # echo the names of virtualenvs available as 'vex VENVNAME'.
-	set dirs (find "$WORKON_HOME" -maxdepth 2 -name "bin" -type d -not -empty -printf '%h\n')
+	set dirs (find "$WORKON_HOME" -maxdepth 2 -name "bin" -type d -not -empty | xargs -n 1 dirname)
 	for NAME in $dirs
 		basename $NAME
 	end
@@ -52,7 +52,7 @@ function __vex_list_commands
 	if [ (count $cmd) -eq 2 -a $cmd[1] = 'vex' ]
 	    set ve "$WORKON_HOME/$cmd[2]"
 	    if test -f "$ve/bin"
-			find "$ve/bin" -maxdepth 1 -executable -printf '%f\n'
+			find "$ve/bin" -maxdepth 1 -executable | xargs basename
 		end
 	end
 	set -l ctoken (commandline -ct)
@@ -62,7 +62,7 @@ end
 # If we source this, we want to wipe out previously defined vex completions
 complete -e -c vex
 # Two positional arguments, a virtualenv and a command.
-complete -c vex -n "__vex_needs_virtualenv" -d "Virtualenv" -f -a "(__vex_list_virtualenvs)" 
+complete -c vex -n "__vex_needs_virtualenv" -d "Virtualenv" -f -a "(__vex_list_virtualenvs)"
 complete -c vex -n "__vex_needs_command" -d "Command from Virtualenv" -x -a "(__vex_list_commands)"
 # Other options.
 complete -c vex -l help -s h -n "__fish_no_arguments" -d "print help information"


### PR DESCRIPTION
`find` on macOS doesn't support `-printf`. See also https://github.com/conda/conda/pull/7575. I suspect this is the case on [FreeBSD][] and [OpenBSD][] as well.

[FreeBSD]: https://www.freebsd.org/cgi/man.cgi?find(1)
[OpenBSD]: https://man.openbsd.org/find.1

Extracted from #63.