### PR TITLE
Switch to `shutil.which` for Python 3.12+ support

### DIFF
--- a/vex/make.py
+++ b/vex/make.py
@@ -1,8 +1,12 @@
 import os
 import sys
-import distutils.spawn
 from vex.run import run
 from vex import exceptions
+
+try:
+    from shutil import which
+except ImportError:
+    from distutils.spawn import find_executable as which
 
 
 PYDOC_SCRIPT = """#!/usr/bin/env python
@@ -47,7 +51,7 @@ def handle_make(environ, options, make_path):
     args = [ve, make_path]
     if options.python:
         if os.name == "nt":
-            python = distutils.spawn.find_executable(options.python)
+            python = which(options.python)
             if python:
                 options.python = python
         args += ["--python", options.python]

--- a/vex/run.py
+++ b/vex/run.py
@@ -3,8 +3,12 @@
 import os
 import platform
 import subprocess
-import distutils.spawn
 from vex import exceptions
+
+try:
+    from shutil import which
+except ImportError:
+    from distutils.spawn import find_executable as which
 
 
 def get_environ(environ, defaults, ve_path):
@@ -71,7 +75,7 @@ def run(command, env, cwd):
     if cwd:
         assert os.path.exists(cwd)
     if platform.system() == "Windows":
-        exe = distutils.spawn.find_executable(command[0], path=env["PATH"])
+        exe = which(command[0], path=env["PATH"])
         if exe:
             command[0] = exe
     _, command_name = os.path.split(command[0])


### PR DESCRIPTION
`distutils` module has been deprecated since Python 3.10 and removed in Python 3.12, see [1] and [2].

Fixes: #70

[1]: https://peps.python.org/pep-0632/
[2]: https://docs.python.org/3.12/library/distutils.html